### PR TITLE
Fix bug: increase number of contributors per page

### DIFF
--- a/collage/_collage.py
+++ b/collage/_collage.py
@@ -9,8 +9,24 @@ from PIL import Image
 from urllib import request
 
 
-def get_contributors(organization, repository, github_username=None, github_token=None):
-    url = f"https://api.github.com/repos/{organization}/{repository}/contributors"
+def get_contributors(
+    organization,
+    repository,
+    github_username=None,
+    github_token=None,
+    contributors_per_page=1000,
+):
+    if not isinstance(contributors_per_page, int):
+        raise ValueError(
+            f"Invalid 'contributors_per_page' of type {type(contributors_per_page)}."
+            "It must be an int."
+        )
+    url = (
+        "https://api.github.com/repos/"
+        f"{organization}/"
+        f"{repository}/"
+        f"contributors?per_page={contributors_per_page}"
+    )
     auth = None
     if github_username is not None and github_token is not None:
         auth = (github_username, github_token)

--- a/collage/cli.py
+++ b/collage/cli.py
@@ -66,6 +66,16 @@ import requests
     show_default=True,
     help="GitHub token for the passed GitHub username.",
 )
+@click.option(
+    "--contributors-per-page",
+    default=1000,
+    show_default=True,
+    help=(
+        "Number of contributors that will be requested to GitHub. "
+        "Make sure this number is higher than the amount of contributors to "
+        "the repository."
+    ),
+)
 def cli(
     image,
     organization,
@@ -78,6 +88,7 @@ def cli(
     fontsize,
     gh_username,
     gh_token,
+    contributors_per_page,
 ):
     from ._collage import get_contributors, get_authors, generate_figure  # lazy imports
 
@@ -102,7 +113,13 @@ def cli(
     # Get contributors
     contributors = []
     for repo in repositories:
-        contributors += get_contributors(organization, repo, gh_username, gh_token)
+        contributors += get_contributors(
+            organization,
+            repo,
+            gh_username,
+            gh_token,
+            contributors_per_page=contributors_per_page,
+        )
     contributors = set(contributors)
 
     # Get authors


### PR DESCRIPTION
Fix a bug related to the GitHub API request for contributors: the number
of contributors returned in the JSON file is caped by the number of
entries per page, which is set by default to 30. Add an option to change
this value through the API and set its default to 1000.
