### PR TITLE
Use multiple=True in a few click options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ Running this helped to generate a nice looking and updated version of the
 SimPEG contributors:
 
 ```sh
-collage --extend-ignore "thibaut-kobold,cgohlke" --include "leonfoks" --ncols 8 --fontsize 24 image.png
+collage \
+  --extend-ignore thibaut-kobold \
+  --extend-ignore cgohlke \
+  --include leonfoks \
+  --ncols 8 \
+  --fontsize 24 \
+  image.png
 ```
 
 ## License

--- a/collage/cli.py
+++ b/collage/cli.py
@@ -14,24 +14,30 @@ import requests
 @click.option(
     "--repositories",
     "-r",
-    default="simpeg,discretize,pydiso,geoana,aurora,pymatsolver",
+    multiple=True,
+    default=["simpeg", "discretize", "pydiso", "geoana", "aurora", "pymatsolver"],
     show_default=True,
     help="List of repositories",
 )
 @click.option(
     "--ignore",
-    default="quantifiedcode-bot",
+    multiple=True,
+    default=["quantifiedcode-bot"],
     show_default=True,
-    help="Ignore this contributors, don't add them to the collage",
+    help="Ignore these contributors, don't add them to the collage",
 )
 @click.option(
     "--extend-ignore",
+    "-e",
+    multiple=True,
     default=None,
     show_default=True,
     help="Extend the list of ignored contributors",
 )
 @click.option(
     "--include",
+    "-i",
+    multiple=True,
     default=None,
     show_default=True,
     help="Include these contributors to the collage",
@@ -82,22 +88,22 @@ def cli(
     from ._collage import get_contributors, get_authors, generate_figure  # lazy imports
 
     # Sanitize inputs
-    repositories = [r.strip() for r in repositories.split(",")]
+    repositories = [r.strip() for r in repositories]
 
     if ignore is None:
         ignore = set()
     else:
-        ignore = set([c.strip() for c in ignore.split(",")])
+        ignore = set([c.strip() for c in ignore])
     if extend_ignore is None:
         extend_ignore = set()
     else:
-        extend_ignore = set([c.strip() for c in extend_ignore.split(",")])
+        extend_ignore = set([c.strip() for c in extend_ignore])
     ignore_contributors = ignore | extend_ignore  # union of the two sets
 
     if include is None:
         include = set()
     else:
-        include = set([c.strip() for c in include.split(",")])
+        include = set([c.strip() for c in include])
 
     # Get contributors
     contributors = []


### PR DESCRIPTION
Use the multiple=True option to list repositories, and to include or
exclude contributors.

Fixes #1
