### PR TITLE
Improve interface for ignored contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ SimPEG contributors:
 
 ```sh
 collage \
-  --extend-ignore thibaut-kobold \
-  --extend-ignore cgohlke \
-  --include leonfoks \
+  --ignore thibaut-kobold \
+  --ignore cgohlke \
+  --add leonfoks \
   --ncols 8 \
   --fontsize 24 \
   image.png


### PR DESCRIPTION
Rename `--include` to `--add`. Remove `--extend-ignore` and make
`--ignore` to extend the default list of ignored contributors. The
default list of ignored contributors is now built in a global variable
or through an envvar.
